### PR TITLE
Implement Subscription Creation

### DIFF
--- a/src/main/java/com/drajer/bsa/ehr/service/EhrQueryService.java
+++ b/src/main/java/com/drajer/bsa/ehr/service/EhrQueryService.java
@@ -29,5 +29,5 @@ public interface EhrQueryService {
 
   void createResource(KarProcessingData kd, Resource resource);
 
-  void deleteResource(KarProcessingData kd, String id);
+  void deleteResource(KarProcessingData kd, ResourceType resourceType, String id);
 }

--- a/src/main/java/com/drajer/bsa/ehr/service/impl/EhrFhirR4QueryServiceImpl.java
+++ b/src/main/java/com/drajer/bsa/ehr/service/impl/EhrFhirR4QueryServiceImpl.java
@@ -121,6 +121,11 @@ public class EhrFhirR4QueryServiceImpl implements EhrQueryService {
     return kd.getFhirInputData();
   }
 
+  /**
+   * @param kd The data object for getting the healthcareSetting and notification context from
+   * @param context The HAPI FHIR context for making a FHIR client with
+   * @return
+   */
   public IGenericClient getClient(KarProcessingData kd, FhirContext context) {
     String secret = kd.getHealthcareSetting().getClientSecret();
     if (secret == null || secret.isEmpty()) {
@@ -135,6 +140,10 @@ public class EhrFhirR4QueryServiceImpl implements EhrQueryService {
         kd.getNotificationContext().getEhrAccessToken());
   }
 
+  /**
+   * @param kd The KarProcessingData includes data about the fhir server to create a resource on
+   * @param resource the resource to create on the fhir server
+   */
   public void createResource(KarProcessingData kd, Resource resource) {
 
     logger.info(" Getting FHIR Context for R4");
@@ -145,7 +154,12 @@ public class EhrFhirR4QueryServiceImpl implements EhrQueryService {
     client.create().resource(resource).execute();
   }
 
-  public void deleteResource(KarProcessingData kd, String id) {
+  /**
+   * @param kd The KarProcessingData which contains information about the fhir server
+   * @param resourceType The resource type of the resource to be deleted
+   * @param id The logical ID of the resource to be deleted
+   */
+  public void deleteResource(KarProcessingData kd, ResourceType resourceType, String id) {
 
     logger.info(" Getting FHIR Context for R4");
     FhirContext context = fhirContextInitializer.getFhirContext(R4);
@@ -153,7 +167,7 @@ public class EhrFhirR4QueryServiceImpl implements EhrQueryService {
     IIdType iIdType = new IdType(id);
     logger.info("Initializing FHIR Client");
     IGenericClient client = getClient(kd, context);
-    client.delete().resourceById(iIdType).execute();
+    client.delete().resourceById(resourceType.toString(), id).execute();
   }
 
   public Resource getResourceById(

--- a/src/main/java/com/drajer/bsa/ehr/subscriptions/impl/SubscriptionGeneratorImpl.java
+++ b/src/main/java/com/drajer/bsa/ehr/subscriptions/impl/SubscriptionGeneratorImpl.java
@@ -49,12 +49,12 @@ public class SubscriptionGeneratorImpl implements SubscriptionGeneratorService {
     this.notificationEndpoint = notificationEndpoint;
   }
 
-  // KarProcessingData fields required to run this:
-  // KarStatus
-  // ehrQueryService
-  // HealthCareSetting
-  // karbundle
-  //
+  /**
+   * Creates a subscription and posts it to the EHR in EhrQueryService
+   *
+   * @param kd The processing context which contains information such as KnowledgeArtifact and
+   *     KnowledgeArtifactStatus
+   */
   public void createSubscriptions(KarProcessingData kd) {
     KnowledgeArtifactStatus status = kd.getKarStatus();
     EhrQueryService ehrQueryService = kd.getEhrQueryService();
@@ -72,12 +72,22 @@ public class SubscriptionGeneratorImpl implements SubscriptionGeneratorService {
     }
   }
 
+  /**
+   * Deletes a subscription from the EHR in EhrQueryService
+   *
+   * @param kd The processing context which contains information such as KnowledgeArtifact and
+   *     KnowledgeArtifactStatus
+   */
   public void deleteSubscriptions(KarProcessingData kd) {
     Set<String> subscriptions = kd.getKarStatus().getSubscriptions();
     EhrQueryService ehrQueryService = kd.getEhrQueryService();
-    subscriptions.forEach(s -> ehrQueryService.deleteResource(kd, s));
+    subscriptions.forEach(s -> ehrQueryService.deleteResource(kd, ResourceType.Subscription, s));
   }
 
+  /**
+   * @param bundle The knowledge artifact bundle
+   * @return A list of subscriptions to be made
+   */
   public List<Subscription> subscriptionsFromBundle(Bundle bundle) {
     List<PlanDefinition> planDefinitions =
         bundle
@@ -93,6 +103,10 @@ public class SubscriptionGeneratorImpl implements SubscriptionGeneratorService {
         .collect(Collectors.toList());
   }
 
+  /**
+   * @param planDefinition The plan definition to make subscriptions from
+   * @return A list of subscriptions to be made
+   */
   public List<Subscription> subscriptionsFromPlanDef(PlanDefinition planDefinition) {
     PlanDefinition.PlanDefinitionActionComponent action = planDefinition.getActionFirstRep();
     String planDefinitionId = planDefinition.getIdElement().getIdPart();
@@ -137,6 +151,13 @@ public class SubscriptionGeneratorImpl implements SubscriptionGeneratorService {
     return subscriptions;
   }
 
+  /**
+   * @param criteria the fhir path specifying what resources to subscribe to
+   * @param notificationEndpoint the endpoint to send the notification
+   * @param id a unique identifier
+   * @param code the triggering event code
+   * @return a populated subscription resource
+   */
   public Subscription generateSubscription(
       String criteria, String notificationEndpoint, String id, String code) {
     Subscription subscription = new Subscription();
@@ -223,25 +244,4 @@ public class SubscriptionGeneratorImpl implements SubscriptionGeneratorService {
         return null;
     }
   }
-
-  //        planDefinition.getAction()
-  //        .stream()
-  //        .filter(
-  //            action ->
-  //                action
-  //                    .getCode()
-  //                    .stream()
-  //                    .anyMatch(
-  //                        codeableConcept ->
-  //                            codeableConcept
-  //                                .getCoding()
-  //                                .stream()
-  //                                .anyMatch(
-  //                                    coding ->
-  //                                        coding
-  //                                            .getCode()
-  //                                            .equals(
-  //                                                BsaTypes.ActionType.InitiateReportingWorkflow
-  //                                                    .toString()))));
-
 }


### PR DESCRIPTION
This adds some functions to the `SubscriptionGenerator` class for making subscriptions from plan definitions and knowledge artifacts.  Posting the subscriptions to the EHR isn't yet done anywhere, since it isn't yet clear where that should be done.  To submit the subscriptions, either the `KarProcessingData` is required or you have to redo a lot of what EHRQueryService already does and get an access token and make a client somewhere else.  

As its set up now, I tried to make use of the code as its written currently, but couldn't find a satisfactory place to call `postSubscriptionToEHR`