### PR TITLE
use BSA to submit report

### DIFF
--- a/src/main/java/com/drajer/bsa/controller/PublicHealthAuthorityController.java
+++ b/src/main/java/com/drajer/bsa/controller/PublicHealthAuthorityController.java
@@ -37,7 +37,7 @@ public class PublicHealthAuthorityController {
 
     if (pha_current == null) {
 
-      logger.info("Healthcare Setting does not exist, Saving the Healthcare Settings");
+      logger.info("Public Health Authority does not exist, Saving the Public Health Authority");
 
       publicHealthAuthorityService.saveOrUpdate(pha);
 

--- a/src/main/java/com/drajer/bsa/controller/PublicHealthAuthorityController.java
+++ b/src/main/java/com/drajer/bsa/controller/PublicHealthAuthorityController.java
@@ -1,0 +1,95 @@
+package com.drajer.bsa.controller;
+
+import com.drajer.bsa.model.PublicHealthAuthority;
+import com.drajer.bsa.service.PublicHealthAuthorityService;
+import java.util.List;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class PublicHealthAuthorityController {
+  private final Logger logger = LoggerFactory.getLogger(PublicHealthAuthorityController.class);
+
+  @Autowired PublicHealthAuthorityService publicHealthAuthorityService;
+
+  @CrossOrigin
+  @RequestMapping("/api/publicHealthAuthority/{phaId}")
+  public PublicHealthAuthority getPublicHealthAuthorityById(@PathVariable("phaId") Integer phaId) {
+    return publicHealthAuthorityService.getPublicHealthAuthorityById(phaId);
+  }
+
+  @CrossOrigin
+  @RequestMapping(value = "/api/publicHealthAuthority", method = RequestMethod.POST)
+  public ResponseEntity<?> createPublicHealthAuthority(@RequestBody PublicHealthAuthority pha) {
+    PublicHealthAuthority pha_current =
+        publicHealthAuthorityService.getPublicHealthAuthorityByUrl(pha.getFhirServerBaseURL());
+
+    if (pha_current == null) {
+
+      logger.info("Healthcare Setting does not exist, Saving the Healthcare Settings");
+
+      publicHealthAuthorityService.saveOrUpdate(pha);
+
+      return new ResponseEntity<>(pha, HttpStatus.OK);
+
+    } else {
+
+      logger.error(
+          "PHA FHIR Server URL is already registered, suggest modifying the existing record.");
+
+      JSONObject responseObject = new JSONObject();
+      responseObject.put("status", "error");
+      responseObject.put(
+          "message",
+          "PHA FHIR Server URL is already registered, suggest modifying the existing record. is already registered");
+      return new ResponseEntity<>(responseObject, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  @CrossOrigin
+  @RequestMapping(value = "/api/publicHealthAuthority", method = RequestMethod.PUT)
+  public ResponseEntity<?> updatePublicHealthAuthority(@RequestBody PublicHealthAuthority pha) {
+    PublicHealthAuthority existingPha =
+        publicHealthAuthorityService.getPublicHealthAuthorityByUrl(pha.getFhirServerBaseURL());
+
+    if (existingPha == null || (existingPha.getId().equals(pha.getId()))) {
+      logger.info("Saving the PHA details");
+      publicHealthAuthorityService.saveOrUpdate(pha);
+      return new ResponseEntity<>(pha, HttpStatus.OK);
+    } else {
+      logger.error(
+          "Public Health Authority is already registered with a different Id which is {}, contact developer. ",
+          existingPha.getId());
+      JSONObject responseObject = new JSONObject();
+      responseObject.put("status", "error");
+      responseObject.put(
+          "message",
+          "Public Health Authority is already registered with a different Id, contact developer. ");
+      return new ResponseEntity<>(responseObject, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  @CrossOrigin
+  @RequestMapping("/api/publicHealthAuthority")
+  public PublicHealthAuthority getPublicHealthAuthorityByUrl(
+      @RequestParam(value = "url") String url) {
+    return publicHealthAuthorityService.getPublicHealthAuthorityByUrl(url);
+  }
+
+  @CrossOrigin
+  @RequestMapping("/api/publicHealthAuthority/")
+  public List<PublicHealthAuthority> getAllPublicHealthAuthority() {
+    return publicHealthAuthorityService.getAllPublicHealthAuthority();
+  }
+}

--- a/src/main/java/com/drajer/bsa/dao/PublicHealthAuthorityDao.java
+++ b/src/main/java/com/drajer/bsa/dao/PublicHealthAuthorityDao.java
@@ -1,0 +1,38 @@
+package com.drajer.bsa.dao;
+
+import com.drajer.bsa.model.PublicHealthAuthority;
+import java.util.List;
+
+public interface PublicHealthAuthorityDao {
+
+  /**
+   * Method to create or update a PublicHealthAuthority.
+   *
+   * @param pha The PublicHealthAuthority details to be used for creation or updating.
+   * @return Returns the PublicHealthAuthority created or updated.
+   */
+  PublicHealthAuthority saveOrUpdate(PublicHealthAuthority pha);
+
+  /**
+   * Method to retrieve a PublicHealthAuthority.
+   *
+   * @param id The PublicHealthAuthority details to be retrieved based on the id.
+   * @return Returns the PublicHealthAuthority for the provided id.
+   */
+  PublicHealthAuthority getPublicHealthAuthorityById(Integer id);
+
+  /**
+   * Method to retrieve a HealthcareSetting by Url.
+   *
+   * @param url The PublicHealthAuthority details to be retrieved based on the url.
+   * @return Returns the PublicHealthAuthority for the provided url.
+   */
+  PublicHealthAuthority getPublicHealthAuthorityByUrl(String url);
+
+  /**
+   * Method to retrieve all existing HealthcareSettings.
+   *
+   * @return Returns the list of existing HealthcareSettings.
+   */
+  List<PublicHealthAuthority> getAllPublicHealthAuthority();
+}

--- a/src/main/java/com/drajer/bsa/dao/impl/PublicHealthAuthorityDaoImpl.java
+++ b/src/main/java/com/drajer/bsa/dao/impl/PublicHealthAuthorityDaoImpl.java
@@ -1,0 +1,47 @@
+package com.drajer.bsa.dao.impl;
+
+import com.drajer.bsa.dao.PublicHealthAuthorityDao;
+import com.drajer.bsa.model.PublicHealthAuthority;
+import com.drajer.ecrapp.dao.AbstractDao;
+import java.util.List;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
+import org.hibernate.Session;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@Transactional
+public class PublicHealthAuthorityDaoImpl extends AbstractDao implements PublicHealthAuthorityDao {
+  @Override
+  public PublicHealthAuthority saveOrUpdate(PublicHealthAuthority pha) {
+    getSession().saveOrUpdate(pha);
+    return pha;
+  }
+
+  @Override
+  public PublicHealthAuthority getPublicHealthAuthorityById(Integer id) {
+    return getSession().get(PublicHealthAuthority.class, id);
+  }
+
+  @Override
+  public PublicHealthAuthority getPublicHealthAuthorityByUrl(String url) {
+    Session session = getSession();
+    CriteriaBuilder cb = session.getCriteriaBuilder();
+    CriteriaQuery<PublicHealthAuthority> criteria = cb.createQuery(PublicHealthAuthority.class);
+    Root<PublicHealthAuthority> root = criteria.from(PublicHealthAuthority.class);
+    criteria.select(root).where(cb.equal(root.get("fhirServerURL"), url)).distinct(true);
+    return session.createQuery(criteria).getSingleResult();
+  }
+
+  @Override
+  public List<PublicHealthAuthority> getAllPublicHealthAuthority() {
+    Session session = getSession();
+    CriteriaBuilder cb = session.getCriteriaBuilder();
+    CriteriaQuery<PublicHealthAuthority> criteria = cb.createQuery(PublicHealthAuthority.class);
+    Root<PublicHealthAuthority> root = criteria.from(PublicHealthAuthority.class);
+    criteria.orderBy(cb.desc(root.get("id")));
+    return session.createQuery(criteria).getResultList();
+  }
+}

--- a/src/main/java/com/drajer/bsa/ehr/service/EhrAuthorizationService.java
+++ b/src/main/java/com/drajer/bsa/ehr/service/EhrAuthorizationService.java
@@ -1,6 +1,7 @@
 package com.drajer.bsa.ehr.service;
 
-import com.drajer.bsa.model.KarProcessingData;
+import com.drajer.bsa.model.FhirServerDetails;
+import org.json.JSONObject;
 
 /**
  *
@@ -16,8 +17,8 @@ public interface EhrAuthorizationService {
   /**
    * The method is used to retrieve the access token from the EHR
    *
-   * @param kd The processing context which contains information such as patient, encounter,
+   * @param fsd The processing context which contains information such as patient, encounter,
    *     previous data etc.
    */
-  public void getAuthorizationToken(KarProcessingData kd);
+  JSONObject getAuthorizationToken(FhirServerDetails fsd);
 }

--- a/src/main/java/com/drajer/bsa/ehr/service/EhrQueryService.java
+++ b/src/main/java/com/drajer/bsa/ehr/service/EhrQueryService.java
@@ -1,10 +1,12 @@
 package com.drajer.bsa.ehr.service;
 
+import com.drajer.bsa.model.FhirServerDetails;
 import com.drajer.bsa.model.KarProcessingData;
 import java.util.HashMap;
 import java.util.Set;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.ResourceType;
+import org.json.JSONObject;
 
 /**
  *
@@ -30,4 +32,11 @@ public interface EhrQueryService {
   void createResource(KarProcessingData kd, Resource resource);
 
   void deleteResource(KarProcessingData kd, ResourceType resourceType, String id);
+  /**
+   * This method is used to get an auth token for accessing the Ehr.
+   *
+   * @param fsd The processing context which contains information such as patient, encounter,
+   *     previous data etc.
+   */
+  JSONObject getToken(FhirServerDetails fsd);
 }

--- a/src/main/java/com/drajer/bsa/ehr/service/impl/BackendAuthorizationServiceImpl.java
+++ b/src/main/java/com/drajer/bsa/ehr/service/impl/BackendAuthorizationServiceImpl.java
@@ -1,7 +1,7 @@
 package com.drajer.bsa.ehr.service.impl;
 
 import com.drajer.bsa.ehr.service.EhrAuthorizationService;
-import com.drajer.bsa.model.KarProcessingData;
+import com.drajer.bsa.model.FhirServerDetails;
 import com.drajer.sof.model.Response;
 import com.jayway.jsonpath.JsonPath;
 import io.jsonwebtoken.Jwts;
@@ -14,7 +14,6 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
-import java.time.Instant;
 import java.util.Date;
 import java.util.Objects;
 import java.util.UUID;
@@ -61,43 +60,44 @@ public class BackendAuthorizationServiceImpl implements EhrAuthorizationService 
   @Value("${jwks.keystore.alias}")
   String alias;
 
-  /** @param kd The processing context which contains information such as patient, encounter */
+  /** @param fsd The processing context which contains information such as patient, encounter */
   @Override
-  public void getAuthorizationToken(KarProcessingData kd) {
-    String baseUrl = kd.getHealthcareSetting().getFhirServerBaseURL();
+  public JSONObject getAuthorizationToken(FhirServerDetails fsd) {
+    String baseUrl = fsd.getFhirServerBaseURL();
     try {
-      JSONObject tokenResponse = connectToServer(baseUrl, kd);
-      kd.getNotificationContext().setEhrAccessToken(tokenResponse.getString("access_token"));
-      kd.getNotificationContext()
-          .setEhrAccessTokenExpiryDuration(tokenResponse.getInt("expires_in"));
-
-      Integer expiresInSec = (Integer) tokenResponse.get("expires_in");
-      Instant expireInstantTime = new Date().toInstant().plusSeconds(Long.valueOf(expiresInSec));
-      kd.getNotificationContext().setEhrAccessTokenExpirationTime(Date.from(expireInstantTime));
+      return connectToServer(baseUrl, fsd);
+      //      return tokenResponse.getString("access_token");
+      //      kd.getNotificationContext()
+      //          .setEhrAccessTokenExpiryDuration(tokenResponse.getInt("expires_in"));
+      //
+      //      Integer expiresInSec = (Integer) tokenResponse.get("expires_in");
+      //      Instant expireInstantTime = new
+      // Date().toInstant().plusSeconds(Long.valueOf(expiresInSec));
+      //
+      // kd.getNotificationContext().setEhrAccessTokenExpirationTime(Date.from(expireInstantTime));
     } catch (Exception e) {
       logger.error(
-          "Error in Getting the AccessToken for the client: {}",
-          kd.getHealthcareSetting().getFhirServerBaseURL(),
-          e);
+          "Error in Getting the AccessToken for the client: {}", fsd.getFhirServerBaseURL(), e);
+      return null;
     }
   }
 
   /**
    * @param url base url of ehr
-   * @param kd knowledge artifact data
+   * @param fsd knowledge artifact data
    * @return the token response from the auth server
    * @throws KeyStoreException in case of invalid public/private keys
    */
-  public JSONObject connectToServer(String url, KarProcessingData kd) throws KeyStoreException {
+  public JSONObject connectToServer(String url, FhirServerDetails fsd) throws KeyStoreException {
     RestTemplate resTemplate = new RestTemplate();
     String tokenEndpoint;
 
-    tokenEndpoint = kd.getHealthcareSetting().getTokenUrl();
+    tokenEndpoint = fsd.getTokenUrl();
     if (tokenEndpoint == null || tokenEndpoint.isEmpty()) {
       tokenEndpoint = getTokenEndpoint(url);
     }
-    String clientId = kd.getHealthcareSetting().getClientId();
-    String scopes = kd.getHealthcareSetting().getScopes();
+    String clientId = fsd.getClientId();
+    String scopes = fsd.getScopes();
     String jwt = generateJwt(clientId, tokenEndpoint);
 
     HttpHeaders headers = new HttpHeaders();

--- a/src/main/java/com/drajer/bsa/ehr/service/impl/BackendAuthorizationServiceImpl.java
+++ b/src/main/java/com/drajer/bsa/ehr/service/impl/BackendAuthorizationServiceImpl.java
@@ -66,15 +66,6 @@ public class BackendAuthorizationServiceImpl implements EhrAuthorizationService 
     String baseUrl = fsd.getFhirServerBaseURL();
     try {
       return connectToServer(baseUrl, fsd);
-      //      return tokenResponse.getString("access_token");
-      //      kd.getNotificationContext()
-      //          .setEhrAccessTokenExpiryDuration(tokenResponse.getInt("expires_in"));
-      //
-      //      Integer expiresInSec = (Integer) tokenResponse.get("expires_in");
-      //      Instant expireInstantTime = new
-      // Date().toInstant().plusSeconds(Long.valueOf(expiresInSec));
-      //
-      // kd.getNotificationContext().setEhrAccessTokenExpirationTime(Date.from(expireInstantTime));
     } catch (Exception e) {
       logger.error(
           "Error in Getting the AccessToken for the client: {}", fsd.getFhirServerBaseURL(), e);

--- a/src/main/java/com/drajer/bsa/ehr/service/impl/EhrAuthorizationServiceImpl.java
+++ b/src/main/java/com/drajer/bsa/ehr/service/impl/EhrAuthorizationServiceImpl.java
@@ -2,11 +2,11 @@ package com.drajer.bsa.ehr.service.impl;
 
 import com.drajer.bsa.ehr.service.EhrAuthorizationService;
 import com.drajer.bsa.model.BsaTypes;
-import com.drajer.bsa.model.KarProcessingData;
+import com.drajer.bsa.model.FhirServerDetails;
 import com.drajer.sof.model.Response;
-import java.time.Instant;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
-import java.util.Date;
+import java.util.Objects;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,19 +39,15 @@ public class EhrAuthorizationServiceImpl implements EhrAuthorizationService {
   private static final String GRANT_TYPE = "grant_type";
 
   @Override
-  public void getAuthorizationToken(KarProcessingData kd) {
+  public JSONObject getAuthorizationToken(FhirServerDetails fsd) {
 
-    JSONObject tokenResponse = null;
-    logger.info(
-        "Getting AccessToken for EHR FHIR URL : {}",
-        kd.getHealthcareSetting().getFhirServerBaseURL());
-    logger.info("Getting AccessToken for Client Id : {}", kd.getHealthcareSetting().getClientId());
+    JSONObject tokenResponse;
+    logger.info("Getting AccessToken for EHR FHIR URL : {}", fsd.getFhirServerBaseURL());
+    logger.info("Getting AccessToken for Client Id : {}", fsd.getClientId());
 
     try {
 
-      if (kd.getHealthcareSetting()
-          .getAuthType()
-          .equals(BsaTypes.getString(BsaTypes.AuthenticationType.SofSystem))) {
+      if (fsd.getAuthType().equals(BsaTypes.getString(BsaTypes.AuthenticationType.SofSystem))) {
 
         logger.info(" System Launch authorization is configured for EHR ");
 
@@ -62,45 +58,32 @@ public class EhrAuthorizationServiceImpl implements EhrAuthorizationService {
         headers.add("Accept", MediaType.APPLICATION_JSON_VALUE);
 
         // Setup the Authorization Header.
-        String authValues =
-            kd.getHealthcareSetting().getClientId()
-                + ":"
-                + kd.getHealthcareSetting().getClientSecret();
+        String authValues = fsd.getClientId() + ":" + fsd.getClientSecret();
         String base64EncodedString =
-            Base64.getEncoder().encodeToString(authValues.getBytes("utf-8"));
+            Base64.getEncoder().encodeToString(authValues.getBytes(StandardCharsets.UTF_8));
         headers.add("Authorization", "Basic " + base64EncodedString);
 
         // Setup the OAuth Type flow.
         MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
         map.add(GRANT_TYPE, "client_credentials");
-        map.add("scope", kd.getHealthcareSetting().getScopes());
+        map.add("scope", fsd.getScopes());
 
-        if (kd.getHealthcareSetting().getRequireAud())
-          map.add("aud", kd.getHealthcareSetting().getFhirServerBaseURL());
+        if (fsd.getRequireAud()) map.add("aud", fsd.getFhirServerBaseURL());
 
         HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(map, headers);
         ResponseEntity<?> response =
-            resTemplate.exchange(
-                kd.getHealthcareSetting().getTokenUrl(), HttpMethod.POST, entity, Response.class);
-        tokenResponse = new JSONObject(response.getBody());
+            resTemplate.exchange(fsd.getTokenUrl(), HttpMethod.POST, entity, Response.class);
+        tokenResponse = new JSONObject(Objects.requireNonNull(response.getBody()));
 
         logger.info("Received AccessToken: {}", tokenResponse);
 
-        kd.getNotificationContext().setEhrAccessToken(tokenResponse.getString("access_token"));
-        kd.getNotificationContext()
-            .setEhrAccessTokenExpiryDuration(tokenResponse.getInt("expires_in"));
-
-        Integer expiresInSec = (Integer) tokenResponse.get("expires_in");
-        Instant expireInstantTime = new Date().toInstant().plusSeconds(new Long(expiresInSec));
-        kd.getNotificationContext()
-            .setEhrAccessTokenExpirationTime(new Date().from(expireInstantTime));
+        return tokenResponse;
       }
 
     } catch (Exception e) {
       logger.error(
-          "Error in Getting the AccessToken for the client: {}",
-          kd.getHealthcareSetting().getFhirServerBaseURL(),
-          e);
+          "Error in Getting the AccessToken for the client: {}", fsd.getFhirServerBaseURL(), e);
     }
+    return null;
   }
 }

--- a/src/main/java/com/drajer/bsa/ehr/service/impl/EhrFhirR4QueryServiceImpl.java
+++ b/src/main/java/com/drajer/bsa/ehr/service/impl/EhrFhirR4QueryServiceImpl.java
@@ -5,8 +5,11 @@ import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
 import com.drajer.bsa.ehr.service.EhrAuthorizationService;
 import com.drajer.bsa.ehr.service.EhrQueryService;
+import com.drajer.bsa.model.FhirServerDetails;
 import com.drajer.bsa.model.KarProcessingData;
 import com.drajer.sof.utils.FhirContextInitializer;
+import java.time.Instant;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -19,6 +22,7 @@ import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.ResourceType;
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -68,7 +72,13 @@ public class EhrFhirR4QueryServiceImpl implements EhrQueryService {
   @Override
   public HashMap<ResourceType, Set<Resource>> getFilteredData(
       KarProcessingData kd, HashMap<String, ResourceType> resTypes) {
+    JSONObject tokenResponse = getToken(kd.getHealthcareSetting());
+    kd.getNotificationContext().setEhrAccessToken(tokenResponse.getString("access_token"));
+    kd.getNotificationContext().setEhrAccessTokenExpiryDuration(tokenResponse.getInt("expires_in"));
 
+    Integer expiresInSec = (Integer) tokenResponse.get("expires_in");
+    Instant expireInstantTime = new Date().toInstant().plusSeconds(Long.valueOf(expiresInSec));
+    kd.getNotificationContext().setEhrAccessTokenExpirationTime(Date.from(expireInstantTime));
     logger.info(" Getting FHIR Context for R4");
     FhirContext context = fhirContextInitializer.getFhirContext(R4);
 
@@ -127,17 +137,12 @@ public class EhrFhirR4QueryServiceImpl implements EhrQueryService {
    * @return
    */
   public IGenericClient getClient(KarProcessingData kd, FhirContext context) {
-    String secret = kd.getHealthcareSetting().getClientSecret();
-    if (secret == null || secret.isEmpty()) {
-      backendAuthorizationService.getAuthorizationToken(kd);
-    } else {
-      ehrAuthorizationService.getAuthorizationToken(kd);
-    }
+    JSONObject token = getToken(kd.getHealthcareSetting());
 
     return fhirContextInitializer.createClient(
         context,
         kd.getHealthcareSetting().getFhirServerBaseURL(),
-        kd.getNotificationContext().getEhrAccessToken());
+        token.getString("access_token"));
   }
 
   /**
@@ -168,6 +173,15 @@ public class EhrFhirR4QueryServiceImpl implements EhrQueryService {
     logger.info("Initializing FHIR Client");
     IGenericClient client = getClient(kd, context);
     client.delete().resourceById(resourceType.toString(), id).execute();
+  }
+  
+  public JSONObject getToken(FhirServerDetails fsd) {
+    String secret = fsd.getClientSecret();
+    if (secret == null || secret.isEmpty()) {
+      return backendAuthorizationService.getAuthorizationToken(fsd);
+    } else {
+      return ehrAuthorizationService.getAuthorizationToken(fsd);
+    }
   }
 
   public Resource getResourceById(
@@ -207,9 +221,9 @@ public class EhrFhirR4QueryServiceImpl implements EhrQueryService {
       String id) {
 
     logger.info("Invoking search url : {}", searchUrl);
-    Set<Resource> resources = null;
-    HashMap<ResourceType, Set<Resource>> resMap = null;
-    HashMap<String, Set<Resource>> resMapById = null;
+    Set<Resource> resources;
+    HashMap<ResourceType, Set<Resource>> resMap;
+    HashMap<String, Set<Resource>> resMapById;
 
     try {
       logger.info(
@@ -229,7 +243,7 @@ public class EhrFhirR4QueryServiceImpl implements EhrQueryService {
 
         if (bc != null) {
 
-          resources = new HashSet<Resource>();
+          resources = new HashSet<>();
           resMap = new HashMap<>();
           resMapById = new HashMap<>();
           for (BundleEntryComponent comp : bc) {

--- a/src/main/java/com/drajer/bsa/ehr/service/impl/EhrFhirR4QueryServiceImpl.java
+++ b/src/main/java/com/drajer/bsa/ehr/service/impl/EhrFhirR4QueryServiceImpl.java
@@ -140,9 +140,7 @@ public class EhrFhirR4QueryServiceImpl implements EhrQueryService {
     JSONObject token = getToken(kd.getHealthcareSetting());
 
     return fhirContextInitializer.createClient(
-        context,
-        kd.getHealthcareSetting().getFhirServerBaseURL(),
-        token.getString("access_token"));
+        context, kd.getHealthcareSetting().getFhirServerBaseURL(), token.getString("access_token"));
   }
 
   /**
@@ -174,7 +172,7 @@ public class EhrFhirR4QueryServiceImpl implements EhrQueryService {
     IGenericClient client = getClient(kd, context);
     client.delete().resourceById(resourceType.toString(), id).execute();
   }
-  
+
   public JSONObject getToken(FhirServerDetails fsd) {
     String secret = fsd.getClientSecret();
     if (secret == null || secret.isEmpty()) {

--- a/src/main/java/com/drajer/bsa/kar/action/SubmitReport.java
+++ b/src/main/java/com/drajer/bsa/kar/action/SubmitReport.java
@@ -98,8 +98,18 @@ public class SubmitReport extends BsaAction {
       BsaActionStatus actStatus,
       String submissionEndpoint) {
         FhirContext context = fhirContextInitializer.getFhirContext(R4);
-        PublicHealthAuthority pha =
-        publicHealthAuthorityService.getPublicHealthAuthorityByUrl(submissionEndpoint);
+        PublicHealthAuthority pha;
+        if (submissionEndpoint.endsWith("/")) {
+          submissionEndpoint = submissionEndpoint.substring(0, submissionEndpoint.length() - 1);
+        }
+        pha = publicHealthAuthorityService.getPublicHealthAuthorityByUrl(submissionEndpoint);
+        if (pha == null) {
+          if (!submissionEndpoint.endsWith("$process-message")) {
+            pha =
+                publicHealthAuthorityService.getPublicHealthAuthorityByUrl(
+                    String.format("%s/$process-message", submissionEndpoint));
+          }
+        }
         String token = "";
         if (pha != null) {
           token = ehrService.getToken(pha).getString("access_token");

--- a/src/main/java/com/drajer/bsa/kar/action/SubmitReport.java
+++ b/src/main/java/com/drajer/bsa/kar/action/SubmitReport.java
@@ -7,11 +7,11 @@ import com.drajer.bsa.ehr.service.EhrQueryService;
 import com.drajer.bsa.kar.model.BsaAction;
 import com.drajer.bsa.model.BsaTypes.BsaActionStatusType;
 import com.drajer.bsa.model.KarProcessingData;
-import java.io.IOException;
-import java.io.InputStream;
 import com.drajer.bsa.model.PublicHealthAuthority;
 import com.drajer.bsa.service.PublicHealthAuthorityService;
 import com.drajer.sof.utils.FhirContextInitializer;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
@@ -97,32 +97,31 @@ public class SubmitReport extends BsaAction {
       EhrQueryService ehrService,
       BsaActionStatus actStatus,
       String submissionEndpoint) {
-        FhirContext context = fhirContextInitializer.getFhirContext(R4);
-        PublicHealthAuthority pha;
-        if (submissionEndpoint.endsWith("/")) {
-          submissionEndpoint = submissionEndpoint.substring(0, submissionEndpoint.length() - 1);
-        }
-        pha = publicHealthAuthorityService.getPublicHealthAuthorityByUrl(submissionEndpoint);
-        if (pha == null) {
-          if (!submissionEndpoint.endsWith("$process-message")) {
-            pha =
-                publicHealthAuthorityService.getPublicHealthAuthorityByUrl(
-                    String.format("%s/$process-message", submissionEndpoint));
-          }
-        }
-        String token = "";
-        if (pha != null) {
-          token = ehrService.getToken(pha).getString("access_token");
-        } else {
-          logger.warn("No PHA was found with submission endpoint {}", submissionEndpoint);
-          logger.warn("Continuing without auth token");
-        }
+    FhirContext context = fhirContextInitializer.getFhirContext(R4);
+    PublicHealthAuthority pha;
+    if (submissionEndpoint.endsWith("/")) {
+      submissionEndpoint = submissionEndpoint.substring(0, submissionEndpoint.length() - 1);
+    }
+    pha = publicHealthAuthorityService.getPublicHealthAuthorityByUrl(submissionEndpoint);
+    if (pha == null) {
+      if (!submissionEndpoint.endsWith("$process-message")) {
+        pha =
+            publicHealthAuthorityService.getPublicHealthAuthorityByUrl(
+                String.format("%s/$process-message", submissionEndpoint));
+      }
+    }
+    String token = "";
+    if (pha != null) {
+      token = ehrService.getToken(pha).getString("access_token");
+    } else {
+      logger.warn("No PHA was found with submission endpoint {}", submissionEndpoint);
+      logger.warn("Continuing without auth token");
+    }
     try (InputStream inputStream =
         SubmitReport.class.getClassLoader().getResourceAsStream("report-headers.properties")) {
       Properties headers = new Properties();
       headers.load(inputStream);
       for (Resource r : resourcesToSubmit) {
-
 
         IGenericClient client =
             fhirContextInitializer.createClient(context, submissionEndpoint, token);

--- a/src/main/java/com/drajer/bsa/model/FhirServerDetails.java
+++ b/src/main/java/com/drajer/bsa/model/FhirServerDetails.java
@@ -1,0 +1,50 @@
+package com.drajer.bsa.model;
+
+import java.util.Date;
+
+public interface FhirServerDetails {
+
+  Integer getId();
+
+  void setId(Integer id);
+
+  String getClientId();
+
+  void setClientId(String clientId);
+
+  String getClientSecret();
+
+  void setClientSecret(String clientSecret);
+
+  String getFhirServerBaseURL();
+
+  void setFhirServerBaseURL(String fhirServerBaseURL);
+
+  String getTokenURL();
+
+  void setTokenURL(String tokenURL);
+
+  String getScopes();
+
+  void setScopes(String scopes);
+
+  Date getLastUpdated();
+
+  void setLastUpdated(Date lastUpdated);
+
+  String getTokenUrl();
+
+  void setTokenUrl(String tokenUrl);
+
+  String getFhirVersion();
+
+  void setFhirVersion(String fhirVersion);
+
+  Boolean getRequireAud();
+
+  void setRequireAud(Boolean requireAud);
+
+  String getAuthType();
+
+  void setAuthType(String authType);
+}

--- a/src/main/java/com/drajer/bsa/model/HealthcareSetting.java
+++ b/src/main/java/com/drajer/bsa/model/HealthcareSetting.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 /**
  *
  *
- * <h1>HealthareSettings</h1>
+ * <h1>HealthcareSettings</h1>
  *
  * The Entity represents a Practice location such as a doctor's office, or a hospital or a network
  * of providers. HealthcareSettings employ EHRs and each EHR is expected to have a FHIR Server. A
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
 @Entity
 @Table(name = "healthcare_setting")
 @DynamicUpdate
-public class HealthcareSetting {
+public class HealthcareSetting implements FhirServerDetails {
 
   @Transient private final Logger logger = LoggerFactory.getLogger(HealthcareSetting.class);
 
@@ -49,7 +49,7 @@ public class HealthcareSetting {
   /**
    * The attribute represents the client secret that is to be used for SMART on FHIR Authorization.
    */
-  @Column(name = "clientSecret", nullable = true, columnDefinition = "TEXT")
+  @Column(name = "clientSecret", columnDefinition = "TEXT")
   private String clientSecret;
 
   /**
@@ -60,14 +60,14 @@ public class HealthcareSetting {
   private String fhirServerBaseURL;
 
   /** The attribute represents the FHIR Server version of the specification supported. */
-  @Column(name = "fhir_version", nullable = true, unique = false)
+  @Column(name = "fhir_version")
   private String fhirVersion;
 
   /**
    * The attribute represents the Token URL for requesting access tokens as part of SMART on FHIR
    * Authorization. This is provided to override what is present in the CapabilityStatement.
    */
-  @Column(name = "token_url", nullable = true, columnDefinition = "TEXT")
+  @Column(name = "token_url", columnDefinition = "TEXT")
   private String tokenUrl;
 
   /**
@@ -82,7 +82,7 @@ public class HealthcareSetting {
    * populated. IF this is not populated the Recipients Address from the Knowledge Artifact will be
    * used.
    */
-  @Column(name = "rest_api_url", nullable = true)
+  @Column(name = "rest_api_url")
   private String restApiUrl;
 
   /**
@@ -91,7 +91,7 @@ public class HealthcareSetting {
    * FHIR Resources updated within time (T) - 2 hours. Where T is the time of the subscription
    * notification.
    */
-  @Column(name = "encounter_start_time", nullable = true)
+  @Column(name = "encounter_start_time")
   private String encounterStartThreshold;
 
   /**
@@ -100,7 +100,7 @@ public class HealthcareSetting {
    * FHIR Resources updated within time (T) + 3 hours. Where T is the time of the subscription
    * notification.
    */
-  @Column(name = "encounter_end_time", nullable = true)
+  @Column(name = "encounter_end_time")
   private String encounterEndThreshold;
 
   /**
@@ -108,7 +108,7 @@ public class HealthcareSetting {
    * HealthcareSetting. This is populated using the HealthcareSettingOperationalKnowledgeArtifacts
    * class which is converted to a JSON string and stored.
    */
-  @Column(name = "kars_active", nullable = true, columnDefinition = "TEXT")
+  @Column(name = "kars_active", columnDefinition = "TEXT")
   private String karsActive;
 
   /** This attribute defines the trusted third party that reports should be submitted to. */
@@ -294,7 +294,7 @@ public class HealthcareSetting {
     logger.info(" Rest API URL : {}", restApiUrl);
     logger.info(" Encounter Start Threshold : {}", encounterStartThreshold);
     logger.info(" Encounter End Threshold : {}", encounterEndThreshold);
-    logger.info(" KnowledgArtifacts Active : {}", karsActive);
+    logger.info(" KnowledgeArtifacts Active : {}", karsActive);
 
     if (kars != null) kars.log();
 

--- a/src/main/java/com/drajer/bsa/model/PublicHealthAuthority.java
+++ b/src/main/java/com/drajer/bsa/model/PublicHealthAuthority.java
@@ -1,0 +1,184 @@
+package com.drajer.bsa.model;
+
+import java.util.Date;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.Type;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ *
+ *
+ * <h1>PublicHealthAuthority</h1>
+ */
+@Entity
+@Table(name = "public_health_authority")
+@DynamicUpdate
+public class PublicHealthAuthority implements FhirServerDetails {
+
+  @Transient private final Logger logger = LoggerFactory.getLogger(HealthcareSetting.class);
+
+  /** The attribute represents the primary key for the table and is auto incremented. */
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  private Integer id;
+
+  /** The attribute represents the client id that is to be used for SMART on FHIR Authorization. */
+  @Column(name = "clientId", nullable = false, columnDefinition = "TEXT")
+  private String clientId;
+
+  /**
+   * The attribute represents the client secret that is to be used for SMART on FHIR Authorization.
+   */
+  @Column(name = "clientSecret", columnDefinition = "TEXT")
+  private String clientSecret;
+
+  /**
+   * The attribute represents the FHIR Server URL for the PublicHealthAuthority. This is unique for
+   * the entire table.
+   */
+  @Column(name = "fhir_server_base_url", nullable = false, unique = true)
+  private String fhirServerBaseURL;
+
+  /** The attribute represents the FHIR Server version of the specification supported. */
+  @Column(name = "fhir_version")
+  private String fhirVersion;
+
+  /**
+   * The attribute represents the Token URL for requesting access tokens as part of SMART on FHIR
+   * Authorization. This is provided to override what is present in the CapabilityStatement.
+   */
+  @Column(name = "token_url", columnDefinition = "TEXT")
+  private String tokenUrl;
+
+  /**
+   * The attribute represents the scopes for which permission is requested during the SMART on FHIR
+   * Authorization. This is provided to override what is present in the CapabilityStatement.
+   */
+  @Column(name = "scopes", nullable = false, columnDefinition = "TEXT")
+  private String scopes;
+
+  @Column(name = "require_aud", nullable = false)
+  @Type(type = "org.hibernate.type.NumericBooleanType")
+  private Boolean requireAud = false;
+
+  /**
+   * This attribute represents the type of authentication to be used by the hpublic health
+   * authority.
+   */
+  @Column(name = "auth_type", nullable = false, columnDefinition = "TEXT")
+  private String authType;
+
+  /** This attribute represents the last time when the object was updated. */
+  @Column(name = "last_updated_ts", nullable = false)
+  @CreationTimestamp
+  private Date lastUpdated;
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public String getClientId() {
+    return clientId;
+  }
+
+  public void setClientId(String clientId) {
+    this.clientId = clientId;
+  }
+
+  public String getClientSecret() {
+    return clientSecret;
+  }
+
+  public void setClientSecret(String clientSecret) {
+    this.clientSecret = clientSecret;
+  }
+
+  public String getFhirServerBaseURL() {
+    return fhirServerBaseURL;
+  }
+
+  public void setFhirServerBaseURL(String fhirServerBaseURL) {
+    this.fhirServerBaseURL = fhirServerBaseURL;
+  }
+
+  public String getTokenURL() {
+    return tokenUrl;
+  }
+
+  public void setTokenURL(String tokenURL) {
+    this.tokenUrl = tokenURL;
+  }
+
+  public String getScopes() {
+    return scopes;
+  }
+
+  public void setScopes(String scopes) {
+    this.scopes = scopes;
+  }
+
+  public Date getLastUpdated() {
+    return lastUpdated;
+  }
+
+  public void setLastUpdated(Date lastUpdated) {
+    this.lastUpdated = lastUpdated;
+  }
+
+  public String getTokenUrl() {
+    return tokenUrl;
+  }
+
+  public void setTokenUrl(String tokenUrl) {
+    this.tokenUrl = tokenUrl;
+  }
+
+  public String getFhirVersion() {
+    return fhirVersion;
+  }
+
+  public void setFhirVersion(String fhirVersion) {
+    this.fhirVersion = fhirVersion;
+  }
+
+  @Override
+  public Boolean getRequireAud() {
+    return null;
+  }
+
+  @Override
+  public void setRequireAud(Boolean requireAud) {}
+
+  @Override
+  public String getAuthType() {
+    return null;
+  }
+
+  @Override
+  public void setAuthType(String authType) {}
+
+  public void log() {
+
+    logger.info(" **** Printing PublicHealthAuthority Details **** ");
+
+    logger.info(" Id : {}", id);
+    logger.info(" Client Id : {}", clientId);
+    logger.info(" FHIR Server URL : {}", fhirServerBaseURL);
+    logger.info(" Token URL : {}", tokenUrl);
+
+    logger.info(" **** End Printing PublicHealthAuthority Details **** ");
+  }
+}

--- a/src/main/java/com/drajer/bsa/service/PublicHealthAuthorityService.java
+++ b/src/main/java/com/drajer/bsa/service/PublicHealthAuthorityService.java
@@ -1,0 +1,38 @@
+package com.drajer.bsa.service;
+
+import com.drajer.bsa.model.PublicHealthAuthority;
+import java.util.List;
+
+public interface PublicHealthAuthorityService {
+
+  /**
+   * Method to create or update a PublicHealthAuthority.
+   *
+   * @param pha The PublicHealthAuthority's details to be used for creation or updation.
+   * @return Returns the PublicHealthAuthority created or updated.
+   */
+  PublicHealthAuthority saveOrUpdate(PublicHealthAuthority pha);
+
+  /**
+   * Method to retrieve a PublicHealthAuthority.
+   *
+   * @param id The PublicHealthAuthority's details to be retrieved based on the id.
+   * @return Returns the PublicHealthAuthority for the provided id.
+   */
+  PublicHealthAuthority getPublicHealthAuthorityById(Integer id);
+
+  /**
+   * Method to retrieve a PublicHealthAuthority.
+   *
+   * @param url The PublicHealthAuthority's details to be retrieved based on the url.
+   * @return Returns the HealthcareSetting for the provided url.
+   */
+  PublicHealthAuthority getPublicHealthAuthorityByUrl(String url);
+
+  /**
+   * Method to retrieve all existing PublicHealthAuthority.
+   *
+   * @return Returns the list of existing PublicHealthAuthority.
+   */
+  List<PublicHealthAuthority> getAllPublicHealthAuthority();
+}

--- a/src/main/java/com/drajer/bsa/service/impl/PublicHealthAuthorityServiceImpl.java
+++ b/src/main/java/com/drajer/bsa/service/impl/PublicHealthAuthorityServiceImpl.java
@@ -1,0 +1,59 @@
+package com.drajer.bsa.service.impl;
+
+import com.drajer.bsa.dao.PublicHealthAuthorityDao;
+import com.drajer.bsa.model.PublicHealthAuthority;
+import com.drajer.bsa.service.PublicHealthAuthorityService;
+import java.util.List;
+import javax.transaction.Transactional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+public class PublicHealthAuthorityServiceImpl implements PublicHealthAuthorityService {
+
+  @Autowired PublicHealthAuthorityDao phaDao;
+  /**
+   * Method to create or update a PublicHealthAuthority.
+   *
+   * @param pha The PublicHealthAuthority details to be used for creation or updating.
+   * @return Returns the PublicHealthAuthority created or updated.
+   */
+  @Override
+  public PublicHealthAuthority saveOrUpdate(PublicHealthAuthority pha) {
+    phaDao.saveOrUpdate(pha);
+    return pha;
+  }
+
+  /**
+   * Method to retrieve a PublicHealthAuthority.
+   *
+   * @param id The PublicHealthAuthority details to be retrieved based on the id.
+   * @return Returns the PublicHealthAuthority for the provided id.
+   */
+  @Override
+  public PublicHealthAuthority getPublicHealthAuthorityById(Integer id) {
+    return phaDao.getPublicHealthAuthorityById(id);
+  }
+
+  /**
+   * Method to retrieve a PublicHealthAuthority.
+   *
+   * @param url The PublicHealthAuthority details to be retrieved based on the url.
+   * @return Returns the PublicHealthAuthority for the provided url.
+   */
+  @Override
+  public PublicHealthAuthority getPublicHealthAuthorityByUrl(String url) {
+    return phaDao.getPublicHealthAuthorityByUrl(url);
+  }
+
+  /**
+   * Method to retrieve all existing HealthcareSettings.
+   *
+   * @return Returns the list of existing HealthcareSettings.
+   */
+  @Override
+  public List<PublicHealthAuthority> getAllPublicHealthAuthority() {
+    return phaDao.getAllPublicHealthAuthority();
+  }
+}


### PR DESCRIPTION
This PR creates a class for `PublicHealthAuthority` and uses it to get an access token for the PHA when submitting reports.  It also refactors some of the auth code for getting access tokens from FHIR servers.  It should mostly function identically as before, with the only real changes being that you can create/update PHA, adding them to the database, and when you submit reports the app will check the `submissionEndpoint` to see if there is a PHA with that endpoint in the database.